### PR TITLE
fix: set retention for data sources to 164h (7 days)

### DIFF
--- a/loki/config.yml
+++ b/loki/config.yml
@@ -50,3 +50,11 @@ table_manager:
   retention_deletes_enabled: false
   retention_period: 0s
 
+compactor:
+  working_directory: /loki/retention
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  retention_period: 164h
+  delete_request_store: filesystem

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -8,3 +8,8 @@ scrape_configs:
     scheme: http
     static_configs:
     - targets: ['otel-collector:8889'] # using the name of the OpenTelemetryCollector container defined in the docker compose file
+
+storage:
+  tsdb:
+    retention:
+      time: 164h

--- a/tempo.yaml
+++ b/tempo.yaml
@@ -22,7 +22,7 @@ ingester:
 
 compactor:
   compaction:
-    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+    block_retention: 164h                # overall Tempo trace retention. set for demo purposes
 
 metrics_generator:
   registry:


### PR DESCRIPTION
- Standardized retention for tempo, loki, and prometheus to 164h (7 days)