### PR TITLE
feat(grafana): seed node dashboard + new alerts

### DIFF
--- a/grafana/dashboards/drosera-operator.json
+++ b/grafana/dashboards/drosera-operator.json
@@ -1,4 +1,5 @@
 {
+  "uid": "feibsm0m2uepse",
   "annotations": {
     "list": [
       {

--- a/grafana/dashboards/seed-node.json
+++ b/grafana/dashboards/seed-node.json
@@ -1,5 +1,4 @@
 {
-    "uid": "aeies2bb7iy2oe",
     "annotations": {
       "list": [
         {
@@ -16,113 +15,12 @@
         }
       ]
     },
-    "description": "Proof server metrics",
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 2,
+    "id": 6,
     "links": [],
     "panels": [
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 0
-        },
-        "id": 1,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
-            },
-            "disableTextWrap": false,
-            "editorMode": "builder",
-            "expr": "proof_server_proof_request_count_total",
-            "fullMetaSearch": false,
-            "includeNullMetadata": true,
-            "instant": false,
-            "legendFormat": "Proof Server",
-            "range": true,
-            "refId": "A",
-            "useBackend": false
-          }
-        ],
-        "title": "Total Proof Requests Received",
-        "type": "timeseries"
-      },
       {
         "datasource": {
           "type": "prometheus",
@@ -165,8 +63,9 @@
                 "mode": "off"
               }
             },
-            "decimals": 4,
+            "fieldMinMax": false,
             "mappings": [],
+            "max": -1,
             "thresholds": {
               "mode": "absolute",
               "steps": [
@@ -179,17 +78,18 @@
                   "value": 80
                 }
               ]
-            }
+            },
+            "unit": "none"
           },
           "overrides": []
         },
         "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
+          "h": 8,
+          "w": 24,
+          "x": 0,
           "y": 0
         },
-        "id": 7,
+        "id": 6,
         "options": {
           "legend": {
             "calcs": [],
@@ -211,17 +111,18 @@
             },
             "disableTextWrap": false,
             "editorMode": "builder",
-            "expr": "proof_server_eth_balance_ETH",
+            "exemplar": false,
+            "expr": "seed_node_connected_peers_count",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
             "instant": false,
-            "legendFormat": "Proof Server: {{proof_server_address}}",
+            "legendFormat": "{{service_name}}",
             "range": true,
             "refId": "A",
             "useBackend": false
           }
         ],
-        "title": "ETH Balance",
+        "title": "Connected Peers",
         "type": "timeseries"
       },
       {
@@ -287,7 +188,7 @@
           "h": 8,
           "w": 8,
           "x": 0,
-          "y": 9
+          "y": 8
         },
         "id": 3,
         "options": {
@@ -311,11 +212,11 @@
             },
             "disableTextWrap": false,
             "editorMode": "builder",
-            "expr": "proof_server_process_memory_usage_MB",
+            "expr": "seed_node_process_memory_usage_MB",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
             "instant": false,
-            "legendFormat": "Proof Server",
+            "legendFormat": "{{service_name}}",
             "range": true,
             "refId": "A",
             "useBackend": false
@@ -387,7 +288,7 @@
           "h": 8,
           "w": 8,
           "x": 8,
-          "y": 9
+          "y": 8
         },
         "id": 4,
         "options": {
@@ -411,11 +312,11 @@
             },
             "disableTextWrap": false,
             "editorMode": "builder",
-            "expr": "proof_server_process_cpu_usage_percent",
+            "expr": "seed_node_process_cpu_usage_percent",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
             "instant": false,
-            "legendFormat": "Proof Server",
+            "legendFormat": "{{service_name}}",
             "range": true,
             "refId": "A",
             "useBackend": false
@@ -487,7 +388,7 @@
           "h": 8,
           "w": 8,
           "x": 16,
-          "y": 9
+          "y": 8
         },
         "id": 5,
         "options": {
@@ -511,11 +412,11 @@
             },
             "disableTextWrap": false,
             "editorMode": "builder",
-            "expr": "proof_server_process_disk_space_usage_MB",
+            "expr": "seed_node_process_disk_space_usage_MB",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
             "instant": false,
-            "legendFormat": "Proof Server",
+            "legendFormat": "{{service_name}}",
             "range": true,
             "refId": "A",
             "useBackend": false
@@ -531,13 +432,14 @@
       "list": []
     },
     "time": {
-      "from": "now-15m",
+      "from": "now-5m",
       "to": "now"
     },
     "timeRangeUpdatedDuringEditOrView": false,
     "timepicker": {},
     "timezone": "browser",
-    "title": "Proof Server",
-    "version": 11,
+    "title": "Drosera Hosted Seed Node",
+    "uid": "bobasm0m2uepse",
+    "version": 3,
     "weekStart": ""
   }

--- a/grafana/provisioning/alerting/alert_rules.yaml
+++ b/grafana/provisioning/alerting/alert_rules.yaml
@@ -3,7 +3,7 @@ groups:
     - orgId: 1
       name: Operator Eval Group
       folder: operator
-      interval: 10m
+      interval: 1m
       rules:
         - uid: aeecqkn99byf4c
           title: Operator Started
@@ -25,7 +25,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -53,7 +53,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -81,7 +81,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -109,11 +109,115 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
             summary: All ETH RPC nodes are unresponsive, operator is shutting down completely
+          isPaused: false
+          notification_settings:
+            receiver: Drosera Slack
+        - uid: eeibub6g9pxq8b
+          title: Operator Low ETH Balance
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 300
+                to: 0
+              datasourceUid: prometheus
+              model:
+                datasource:
+                    type: prometheus
+                    uid: prometheus
+                disableTextWrap: false
+                editorMode: builder
+                exemplar: false
+                expr: eth_balance_ETH
+                format: table
+                fullMetaSearch: false
+                includeNullMetadata: true
+                instant: true
+                interval: ""
+                intervalMs: 30000
+                legendFormat: 'Operator: {{operator_address}}'
+                maxDataPoints: 43200
+                range: false
+                refId: A
+                useBackend: false
+            - refId: C
+              relativeTimeRange:
+                from: 300
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0.05
+                        type: lt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 30000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: feibsm0m2uepse
+          panelId: 7
+          noDataState: OK
+          execErrState: Error
+          for: 0s
+          annotations:
+            __dashboardUid__: feibsm0m2uepse
+            __panelId__: "7"
+            description: "The operator {{ $labels.operator_address }} has fallen below the minimum threshold for a safe ETH balance. Current balance: {{ $values.A.Value }} ETH"
+            summary: "Low ETH Balance ({{ $values.A.Value }} ETH)"
+          labels: {}
+          isPaused: false
+          notification_settings:
+            receiver: Drosera Slack
+        - uid: i7r1le9mw2epxk
+          title: Operator High CPU %
+          condition: A
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 300  # 5 minutes
+                to: 0
+              datasourceUid: prometheus
+              model:
+                disableTextWrap: false
+                editorMode: builder
+                expr: avg_over_time(drosera_process_cpu_usage_percent[5m]) > 75
+                fullMetaSearch: false
+                includeNullMetadata: true
+                instant: true
+                intervalMs: 30000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+                useBackend: false
+          noDataState: OK
+          execErrState: Error
+          for: 0s
+          annotations:
+            description: "The operator CPU percentage has breached 75% for the past 5 minutes on average"
+            summary: "High operator CPU percentage ({{ $values.A.Value }}%)"
+            __dashboardUid__: feibsm0m2uepse
+            __panelId__: "4"
+          labels: {}
           isPaused: false
           notification_settings:
             receiver: Drosera Slack
@@ -142,7 +246,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -170,7 +274,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -198,7 +302,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -226,11 +330,45 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
             summary: All ETH RPC nodes are unresponsive, seed node is shutting down completely
+          isPaused: false
+          notification_settings:
+            receiver: Drosera Slack
+        - uid: o9x4le9mw2hj7f
+          title: Seed Node High CPU %
+          condition: A
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 300  # 5 minutes
+                to: 0
+              datasourceUid: prometheus
+              model:
+                disableTextWrap: false
+                editorMode: builder
+                expr: avg_over_time(seed_node_process_cpu_usage_percent[5m]) > 75
+                fullMetaSearch: false
+                includeNullMetadata: true
+                instant: true
+                intervalMs: 30000
+                legendFormat: __auto
+                maxDataPoints: 43200
+                range: false
+                refId: A
+                useBackend: false
+          noDataState: OK
+          execErrState: Error
+          for: 0s
+          annotations:
+            description: "The seed node CPU percentage has breached 75% for the past 5 minutes on average"
+            summary: "High seed node CPU percentage ({{ $values.A.Value }}%)"
+            __dashboardUid__: bobasm0m2uepse
+            __panelId__: "4"
+          labels: {}
           isPaused: false
           notification_settings:
             receiver: Drosera Slack
@@ -259,7 +397,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -287,7 +425,7 @@ groups:
                 maxDataPoints: 43200
                 queryType: instant
                 refId: A
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
@@ -301,13 +439,13 @@ groups:
           data:
             - refId: A
               relativeTimeRange:
-                from: 600
+                from: 300  # 5 minutes
                 to: 0
               datasourceUid: prometheus
               model:
                 disableTextWrap: false
                 editorMode: builder
-                expr: avg_over_time(proof_server_process_cpu_usage_percent[1m]) > 75
+                expr: avg_over_time(proof_server_process_cpu_usage_percent[5m]) > 75
                 fullMetaSearch: false
                 includeNullMetadata: true
                 instant: true
@@ -317,12 +455,14 @@ groups:
                 range: false
                 refId: A
                 useBackend: false
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
-            description: The proof server CPU percentage has breached 75% for the past 1 minute on average
-            summary: High proof server CPU percentage
+            description: "The proof server CPU percentage has breached 75% for the past 5 minutes on average"
+            summary: "High proof server CPU percentage ({{ $values.A.Value }}%)"
+            __dashboardUid__: aeies2bb7iy2oe
+            __panelId__: "4"
           labels: {}
           isPaused: false
           notification_settings:
@@ -349,12 +489,84 @@ groups:
                 range: false
                 refId: A
                 useBackend: false
-          noDataState: NoData
+          noDataState: OK
           execErrState: Error
           for: 0s
           annotations:
             description: The proof server is using more than 1 GB of storage
             summary: High proof server storage usage
+            __dashboardUid__: aeies2bb7iy2oe
+            __panelId__: "5"
+          labels: {}
+          isPaused: false
+          notification_settings:
+            receiver: Drosera Slack
+        - uid: proofb6g9px7fs
+          title: Proof Server Low ETH Balance
+          condition: C
+          data:
+            - refId: A
+              relativeTimeRange:
+                from: 300
+                to: 0
+              datasourceUid: prometheus
+              model:
+                datasource:
+                    type: prometheus
+                    uid: prometheus
+                disableTextWrap: false
+                editorMode: builder
+                exemplar: false
+                expr: proof_server_eth_balance_ETH
+                format: table
+                fullMetaSearch: false
+                includeNullMetadata: true
+                instant: true
+                interval: ""
+                intervalMs: 30000
+                legendFormat: 'Proof Server: {{operator_address}}'
+                maxDataPoints: 43200
+                range: false
+                refId: A
+                useBackend: false
+            - refId: C
+              relativeTimeRange:
+                from: 300
+                to: 0
+              datasourceUid: __expr__
+              model:
+                conditions:
+                    - evaluator:
+                        params:
+                            - 0.05
+                        type: lt
+                      operator:
+                        type: and
+                      query:
+                        params:
+                            - C
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                datasource:
+                    type: __expr__
+                    uid: __expr__
+                expression: A
+                intervalMs: 30000
+                maxDataPoints: 43200
+                refId: C
+                type: threshold
+          dashboardUid: aeies2bb7iy2oe
+          panelId: 7
+          noDataState: OK
+          execErrState: Error
+          for: 0s
+          annotations:
+            __dashboardUid__: aeies2bb7iy2oe
+            __panelId__: "7"
+            description: "The operator {{ $labels.operator_address }} has fallen below the minimum threshold for a safe ETH balance. Current balance: {{ $values.A.Value }} ETH"
+            summary: "Low ETH Balance ({{ $values.A.Value }} ETH)"
           labels: {}
           isPaused: false
           notification_settings:


### PR DESCRIPTION
- Seed node dashboard
- CPU % alert for operator and seed node
- Low ETH alert for operator and proof server
- Linked relevant alerts to their respective dashboard panels
- Turn off resolve messages to reduce notification count
- A few small minute changes